### PR TITLE
Feature/extend textile issue quickinfo

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -774,7 +774,7 @@ module ApplicationHelper
         elsif sep == '###'
           oid = identifier.to_i
           if issue = Issue.visible.find_by_id(oid, :include => :status)
-            link = issue_quick_info_with_description(issue,3)
+            link = issue_quick_info_with_description(issue)
           end
         elsif sep == ':'
           # removes the double quotes if any
@@ -929,7 +929,7 @@ module ApplicationHelper
     " | " +
     link_to_function(l(:button_uncheck_all), "checkAll('#{form_name}', false)")
   end
-  
+
   def progress_bar(pcts, options={})
     pcts = [pcts, pcts] unless pcts.is_a?(Array)
     pcts = pcts.collect(&:round)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -724,7 +724,7 @@ module ApplicationHelper
   #     identifier:version:1.0.0
   #     identifier:source:some/file
   def parse_redmine_links(text, project, obj, attr, only_path, options)
-    text.gsub!(%r{([\s\(,\-\[\>]|^)(!)?(([a-z0-9\-]+):)?(attachment|document|version|commit|source|export|message|project)?((#|r)(\d+)|(:)([^"\s<>][^\s<>]*?|"[^"]+?"))(?=(?=[[:punct:]]\W)|,|\s|\]|<|$)}) do |m|
+    text.gsub!(%r{([\s\(,\-\[\>]|^)(!)?(([a-z0-9\-]+):)?(attachment|document|version|commit|source|export|message|project)?((#+|r)(\d+)|(:)([^"\s<>][^\s<>]*?|"[^"]+?"))(?=(?=[[:punct:]]\W)|,|\s|\]|<|$)}) do |m|
       leading, esc, project_prefix, project_identifier, prefix, sep, identifier = $1, $2, $3, $4, $5, $7 || $9, $8 || $10
       link = nil
       if project_identifier
@@ -765,6 +765,16 @@ module ApplicationHelper
             if p = Project.visible.find_by_id(oid)
               link = link_to_project(p, {:only_path => only_path}, :class => 'project')
             end
+          end
+        elsif sep == '##'
+          oid = identifier.to_i
+          if issue = Issue.visible.find_by_id(oid, :include => :status)
+            link = issue_quick_info(issue)
+          end
+        elsif sep == '###'
+          oid = identifier.to_i
+          if issue = Issue.visible.find_by_id(oid, :include => :status)
+            link = issue_quick_info_with_description(issue,3)
           end
         elsif sep == ':'
           # removes the double quotes if any

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -235,7 +235,9 @@ module IssuesHelper
   end
 
   def issue_quick_info_with_description(issue, lines)
+    limited_description = issue.description.to_s.lines.to_a[0,lines + 1].to_s
+
     issue_quick_info(issue) +
-      content_tag(:div, textilizable("\n" + issue.description.to_s.lines[0,lines + 1].to_s), :class => "indent")
+      content_tag(:div, textilizable("\n" + limited_description), :class => "indent")
   end
 end

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -226,12 +226,14 @@ module IssuesHelper
   end
 
   def issue_quick_info(issue)
-    link_to("##{issue.id} #{issue.status}: #{issue.subject} ",
-            {:controller => 'issues', :action => 'show', :id => issue.id},
-             :class => issue.css_classes,
-             :title => "#{truncate(issue.subject, :length => 100)} (#{issue.status.name})") +
-    "#{issue.start_date.nil? ? "[?]" : issue.start_date.to_s} - #{issue.due_date.nil? ? "[?]" : issue.due_date.to_s}" +
-     "#{issue.assigned_to.nil? ? " " : " (#{issue.assigned_to.to_s})"}"
+    ret = link_to(h("##{issue.id} #{issue.status}: #{issue.subject} "),
+                  { :controller => 'issues', :action => 'show', :id => issue.id },
+                    :class => issue.css_classes,
+                    :title => "#{ truncate(issue.subject, :length => 100) } (#{ issue.status.name })")
+    ret += "#{ issue.start_date.nil? ? "[?]" : issue.start_date.to_s }"
+    ret += " - #{ issue.due_date.nil? ? "[?]" : issue.due_date.to_s }"
+    ret += "#{ issue.assigned_to.nil? ?  " " : " (#{h(issue.assigned_to.to_s)})" }"
+    ret
   end
 
   def issue_quick_info_with_description(issue, lines = 3)

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -234,7 +234,7 @@ module IssuesHelper
      "#{issue.assigned_to.nil? ? " " : " (#{issue.assigned_to.to_s})"}"
   end
 
-  def issue_quick_info_with_description(issue, lines)
+  def issue_quick_info_with_description(issue, lines = 3)
     limited_description = issue.description.to_s.lines.to_a[0,lines + 1].to_s
 
     issue_quick_info(issue) +

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -224,4 +224,18 @@ module IssuesHelper
 
 
   end
+
+  def issue_quick_info(issue)
+    link_to("##{issue.id} #{issue.status}: #{issue.subject} ",
+            {:controller => 'issues', :action => 'show', :id => issue.id},
+             :class => issue.css_classes,
+             :title => "#{truncate(issue.subject, :length => 100)} (#{issue.status.name})") +
+    "#{issue.start_date.nil? ? "[?]" : issue.start_date.to_s} - #{issue.due_date.nil? ? "[?]" : issue.due_date.to_s}" +
+     "#{issue.assigned_to.nil? ? " " : " (#{issue.assigned_to.to_s})"}"
+  end
+
+  def issue_quick_info_with_description(issue, lines)
+    issue_quick_info(issue) +
+      content_tag(:div, textilizable("\n" + issue.description.to_s.lines[0,lines + 1].to_s), :class => "indent")
+  end
 end

--- a/app/views/help/wiki_syntax.html.erb
+++ b/app/views/help/wiki_syntax.html.erb
@@ -44,6 +44,8 @@
 <tr><th><img src="../images/jstoolbar/bt_link.png" style="border: 1px solid #bbb;" alt="Link to a Wiki page" /></th><td>[[Wiki page]]</td><td><a href="#">Wiki page</a></td></tr>
 <tr><th><img src="../images/jstoolbar/bt_link.png" style="border: 1px solid #bbb;" alt="Link to a Wiki page" /></th><td>[[Sandbox:Wiki page]]</td><td><a href="#">Wiki page</a> (On the Sandbox project)</td></tr>
 <tr><th></th><td>Issue #12</td><td>Issue <a href="#">#12</a></td></tr>
+<tr><th></th><td>##12</td><td>Link with additional information</td></tr>
+<tr><th></th><td>###12</td><td>Link with additional information + description</td></tr>
 <tr><th></th><td>Revision r43</td><td>Revision <a href="#">r43</a></td></tr>
 <tr><th></th><td>commit:f30e13e43</td><td><a href="#">f30e13e4</a></td></tr>
 <tr><th></th><td>source:some/file</td><td><a href="#">source:some/file</a></td></tr>

--- a/app/views/help/wiki_syntax_detailed.html.erb
+++ b/app/views/help/wiki_syntax_detailed.html.erb
@@ -39,6 +39,8 @@
         <p>ChiliProject allows hyperlinking between issues, changesets and wiki pages from anywhere wiki formatting is used.</p>
         <ul>
             <li>Link to an issue: <strong>#124</strong> (displays <del><a href="#" class="issue" title="bulk edit doesn't change the category or fixed version properties (Closed)">#124</a></del>, link is striked-through if the issue is closed)</li>
+            <li>Link to an issue with additional information: <strong>##124</strong> (displays <a href="/issues/12" class="issue status-1 priority-2 overdue created-by-me" title="test (New)">#12 New: Issue subject </a> 2012-05-14 - 2012-05-23 (User Name - assigned to)</li>
+            <li>Link to an issue with additional information and an excerpt of the description: <strong>###124</strong> (additionally displays 3 lines of the description of the issue)</li>
             <li>Link to a changeset: <strong>r758</strong> (displays <a href="#" class="changeset" title="Search engine now only searches objects the user is allowed to view.">r758</a>)</li>
             <li>Link to a changeset with a non-numeric hash: <strong>commit:c6f4d0fd</strong> (displays <a href="#" class="changeset">c6f4d0fd</a>).</li>
             <li>Link to a changeset of another project: <strong>sandbox:r758</strong> (displays <a href="#" class="changeset" title="Search engine now only searches objects the user is allowed to view.">sandbox:r758</a>)</li>

--- a/app/views/help/wiki_syntax_detailed.html.erb
+++ b/app/views/help/wiki_syntax_detailed.html.erb
@@ -38,13 +38,13 @@
 
         <p>ChiliProject allows hyperlinking between issues, changesets and wiki pages from anywhere wiki formatting is used.</p>
         <ul>
-            <li>Link to an issue: <strong>#124</strong> (displays <del><a href="#" class="issue" title="bulk edit doesn't change the category or fixed version properties (Closed)">#124</a></del>, link is striked-through if the issue is closed)</li>
-            <li>Link to an issue with additional information: <strong>##124</strong> (displays <a href="/issues/12" class="issue status-1 priority-2 overdue created-by-me" title="test (New)">#12 New: Issue subject </a> 2012-05-14 - 2012-05-23 (User Name - assigned to)</li>
-            <li>Link to an issue with additional information and an excerpt of the description: <strong>###124</strong> (additionally displays 3 lines of the description of the issue)</li>
-            <li>Link to a changeset: <strong>r758</strong> (displays <a href="#" class="changeset" title="Search engine now only searches objects the user is allowed to view.">r758</a>)</li>
-            <li>Link to a changeset with a non-numeric hash: <strong>commit:c6f4d0fd</strong> (displays <a href="#" class="changeset">c6f4d0fd</a>).</li>
-            <li>Link to a changeset of another project: <strong>sandbox:r758</strong> (displays <a href="#" class="changeset" title="Search engine now only searches objects the user is allowed to view.">sandbox:r758</a>)</li>
-            <li>Link to a changeset with a non-numeric hash: <strong>sandbox:c6f4d0fd</strong> (displays <a href="#" class="changeset">sandbox:c6f4d0fd</a>).</li>
+            <li><strong>#124</strong> displays a link to an issue: <del><a href="#" class="issue" title="bulk edit doesn't change the category or fixed version properties (Closed)">#124</a></del> (link is striked-through if the issue is closed)</li>
+            <li><strong>##124</strong> displays a link to an issue with additional information: <a href="/issues/12" class="issue status-1 priority-2 overdue created-by-me" title="Issue subject (New)">#12 New: Issue subject</a> 2012-05-14 - 2012-05-23 (User Name - assigned to)</li>
+            <li><strong>###124</strong> displays a link to an issue with additional information and an excerpt (first 3 lines) of the description</li>
+            <li><strong>r758</strong> displays a link to a changeset: <a href="#" class="changeset" title="Search engine now only searches objects the user is allowed to view.">r758</a></li>
+            <li><strong>commit:c6f4d0fd</strong> displays a link to a changeset with a non-numeric hash: <a href="#" class="changeset">c6f4d0fd</a></li>
+            <li><strong>sandbox:r758</strong> displays a link to a changeset of another project: <a href="#" class="changeset" title="Search engine now only searches objects the user is allowed to view.">sandbox:r758</a></li>
+            <li><strong>sandbox:c6f4d0fd</strong> displays a link to a changeset with a non-numeric hash: <a href="#" class="changeset">sandbox:c6f4d0fd</a></li>
         </ul>
 
         <p>Wiki links:</p>

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -2948,3 +2948,6 @@ strong.related-issues-heading {
   display:block;
   margin-top: 10px;
 }
+div.indent {
+  padding-left: 10px;
+}


### PR DESCRIPTION
extend issue link macro functionality by 2/3 hashes

2 hashes show a quickinfo like #12 New: Subject 2012-05-14 - 2012-05-23 (Romano Licker)
3 hashes show the quickinfo + description (3 rows)

see plugins/chiliproject_tests for integration tests
