### PR TITLE
Project hierarchy sorting

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -314,7 +314,7 @@ module ApplicationHelper
     s = ''
     if projects.any?
       ancestors = []
-      projects.sort_by(&:lft).each do |project|
+      Project.project_tree(projects) do |project, level|
         if (ancestors.empty? || project.is_descendant_of?(ancestors.last))
           s << "<ul>\n"
         else

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -55,7 +55,7 @@ module ProjectsHelper
     if projects.any?
       ancestors = []
       original_project = @project
-      projects.each do |project|
+      Project.project_tree(projects) do |project, level|
         # set the project environment to please macros.
         @project = project
         if (ancestors.empty? || project.is_descendant_of?(ancestors.last))


### PR DESCRIPTION
builds up a helper structure in order to sort each project level in a project hierarchy by name even if it is only a subset (where it didn't wok before)
