### PR TITLE
Feature/wiki syntax help page

### DIFF
--- a/app/views/help/wiki_syntax.html.erb
+++ b/app/views/help/wiki_syntax.html.erb
@@ -44,8 +44,9 @@
 <tr><th><img src="../images/jstoolbar/bt_link.png" style="border: 1px solid #bbb;" alt="Link to a Wiki page" /></th><td>[[Wiki page]]</td><td><a href="#">Wiki page</a></td></tr>
 <tr><th><img src="../images/jstoolbar/bt_link.png" style="border: 1px solid #bbb;" alt="Link to a Wiki page" /></th><td>[[Sandbox:Wiki page]]</td><td><a href="#">Wiki page</a> (On the Sandbox project)</td></tr>
 <tr><th></th><td>Issue #12</td><td>Issue <a href="#">#12</a></td></tr>
-<tr><th></th><td>##12</td><td>Issue #12 with context information</td></tr>
-<tr><th></th><td>###12</td><td>Issue #12 with context information + description</td></tr>
+<tr><th></th><td>##12</td><td>Bug #12 New: Name of issue 2012-06-06 – 2013-06-06 (John Doe)</td></tr>
+<tr><th></th><td>###12</td><td>Bug #12 New: Name of issue 2012-06-06 – 2013-06-06 (John Doe)
+I am the description of this issue.</td></tr>
 <tr><th></th><td>Revision r43</td><td>Revision <a href="#">r43</a></td></tr>
 <tr><th></th><td>commit:f30e13e43</td><td><a href="#">f30e13e4</a></td></tr>
 <tr><th></th><td>source:some/file</td><td><a href="#">source:some/file</a></td></tr>

--- a/app/views/help/wiki_syntax.html.erb
+++ b/app/views/help/wiki_syntax.html.erb
@@ -44,8 +44,8 @@
 <tr><th><img src="../images/jstoolbar/bt_link.png" style="border: 1px solid #bbb;" alt="Link to a Wiki page" /></th><td>[[Wiki page]]</td><td><a href="#">Wiki page</a></td></tr>
 <tr><th><img src="../images/jstoolbar/bt_link.png" style="border: 1px solid #bbb;" alt="Link to a Wiki page" /></th><td>[[Sandbox:Wiki page]]</td><td><a href="#">Wiki page</a> (On the Sandbox project)</td></tr>
 <tr><th></th><td>Issue #12</td><td>Issue <a href="#">#12</a></td></tr>
-<tr><th></th><td>##12</td><td>Link with additional information</td></tr>
-<tr><th></th><td>###12</td><td>Link with additional information + description</td></tr>
+<tr><th></th><td>##12</td><td>Issue #12 with context information</td></tr>
+<tr><th></th><td>###12</td><td>Issue #12 with context information + description</td></tr>
 <tr><th></th><td>Revision r43</td><td>Revision <a href="#">r43</a></td></tr>
 <tr><th></th><td>commit:f30e13e43</td><td><a href="#">f30e13e4</a></td></tr>
 <tr><th></th><td>source:some/file</td><td><a href="#">source:some/file</a></td></tr>

--- a/app/views/help/wiki_syntax_detailed.html.erb
+++ b/app/views/help/wiki_syntax_detailed.html.erb
@@ -39,8 +39,8 @@
         <p>ChiliProject allows hyperlinking between issues, changesets and wiki pages from anywhere wiki formatting is used.</p>
         <ul>
             <li><strong>#124</strong> displays a link to an issue: <del><a href="#" class="issue" title="bulk edit doesn't change the category or fixed version properties (Closed)">#124</a></del> (link is striked-through if the issue is closed)</li>
-            <li><strong>##124</strong> displays a link to an issue with additional information: <a href="/issues/12" class="issue status-1 priority-2 overdue created-by-me" title="Issue subject (New)">#12 New: Issue subject</a> 2012-05-14 - 2012-05-23 (User Name - assigned to)</li>
-            <li><strong>###124</strong> displays a link to an issue with additional information and an excerpt (first 3 lines) of the description</li>
+            <li><strong>##124</strong> displays a link to an issue with context information: <a href="/issues/12" class="issue status-1 priority-2 overdue created-by-me" title="Issue subject (New)">#12 New: Issue subject</a> 2012-05-14 - 2012-05-23 (User Name - assigned to)</li>
+            <li><strong>###124</strong> displays a link to an issue with context information and an excerpt (first 3 lines) of the description</li>
             <li><strong>r758</strong> displays a link to a changeset: <a href="#" class="changeset" title="Search engine now only searches objects the user is allowed to view.">r758</a></li>
             <li><strong>commit:c6f4d0fd</strong> displays a link to a changeset with a non-numeric hash: <a href="#" class="changeset">c6f4d0fd</a></li>
             <li><strong>sandbox:r758</strong> displays a link to a changeset of another project: <a href="#" class="changeset" title="Search engine now only searches objects the user is allowed to view.">sandbox:r758</a></li>

--- a/lib/redmine/wiki_formatting/textile/helper.rb
+++ b/lib/redmine/wiki_formatting/textile/helper.rb
@@ -20,7 +20,7 @@ module Redmine
           heads_for_wiki_formatter
           url = url_for(:controller => 'help', :action => 'wiki_syntax')
           help_link = link_to(l(:setting_text_formatting), url,
-                              :onclick => "window.open(\"#{ url }\", \"\", \"resizable=yes, location=no, width=300, height=640, menubar=no, status=no, scrollbars=yes\"); return false;")
+                              :onclick => "window.open(\"#{ url }\", \"\", \"resizable=yes, location=no, width=600, height=640, menubar=no, status=no, scrollbars=yes\"); return false;")
 
           javascript_tag("var wikiToolbar = new jsToolBar($('#{field_id}')); wikiToolbar.setHelpLink('#{escape_javascript help_link}'); wikiToolbar.draw();")
         end


### PR DESCRIPTION
- additional information -> context information
- outline "issue" instead of "link"
