### PR TITLE
Fix/remove plugin safe attributes from wiki

### DIFF
--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -25,7 +25,7 @@ class Wiki < ActiveRecord::Base
   validates_presence_of :start_page
   validates_format_of :start_page, :with => /^[^,\.\/\?\;\|\:]*$/
 
-  safe_attributes 'start_page', 'tabs_attributes'
+  safe_attributes 'start_page'
 
   def visible?(user=User.current)
     !user.nil? && user.allowed_to?(:view_wiki_pages, project)


### PR DESCRIPTION
- tab_attributes are plugin specific

This reverts commit 284f689bd719afdedd4d298baaf9d6190dd3c391.
