### PR TITLE
Feature/reset sort when clear

### DIFF
--- a/app/views/issues/index.rhtml
+++ b/app/views/issues/index.rhtml
@@ -49,7 +49,7 @@
                        }, :class => 'icon icon-checked' %>
 
     <%= link_to_remote l(:button_clear),
-                       { :url => { :set_filter => 1, :project_id => @project },
+                       { :url => { :set_filter => 1, :sort => 'parent:desc', :project_id => @project },
                          :method => :get,
                          :update => "content",
                        }, :class => 'icon icon-reload'  %>


### PR DESCRIPTION
explicitly passing the default sort parameter resets it rather than taking the old value from the session. fixes #35243
