### PR TITLE
Feature/avoid nil to empty string transition on journals

### DIFF
--- a/vendor/plugins/acts_as_journalized/lib/redmine/acts/journalized/changes.rb
+++ b/vendor/plugins/acts_as_journalized/lib/redmine/acts/journalized/changes.rb
@@ -89,7 +89,11 @@ module Redmine::Acts::Journalized
         # creation. Incremental changes are reset when the record is saved because they represent
         # a subset of the dirty attribute changes, which are reset upon save.
         def incremental_journal_changes
-          changed.inject({}) { |h, attr| h[attr] = attribute_change(attr); h }.slice(*journaled_columns)
+          changed.inject({}) do |h, attr|
+            h[attr] = attribute_change(attr) unless !attribute_change(attr).nil? &&
+              attribute_change(attr)[0].blank? && attribute_change(attr)[1].blank?
+            h
+          end.slice(*journaled_columns)
         end
 
         # Simply resets the cumulative changes after journal creation.

--- a/vendor/plugins/acts_as_journalized/lib/redmine/acts/journalized/changes.rb
+++ b/vendor/plugins/acts_as_journalized/lib/redmine/acts/journalized/changes.rb
@@ -89,11 +89,9 @@ module Redmine::Acts::Journalized
         # creation. Incremental changes are reset when the record is saved because they represent
         # a subset of the dirty attribute changes, which are reset upon save.
         def incremental_journal_changes
-          changed.inject({}) do |h, attr|
-            h[attr] = attribute_change(attr) unless !attribute_change(attr).nil? &&
-              attribute_change(attr)[0].blank? && attribute_change(attr)[1].blank?
-            h
-          end.slice(*journaled_columns)
+          changes.slice(*journaled_columns).reject do |k, (was, is)|
+                                              was.blank? && is.blank?
+                                            end
         end
 
         # Simply resets the cumulative changes after journal creation.


### PR DESCRIPTION
do not create a journal when attributes change from
blank to blank (eg. nil -> "")

we first came in contact with the problem when
issue journals were created stating "description deleted"
although there has never been any description on that object

Please also check the tests which can be found in the plugin **chiliproject_tests** in the branch **feature/avoid_nil_to_empty_string_transition_on_journals**
