### PR TITLE
mark columns as summable

### DIFF
--- a/app/helpers/issue_list_sums_helper.rb
+++ b/app/helpers/issue_list_sums_helper.rb
@@ -37,7 +37,7 @@ module IssueListSumsHelper
     return unless should_be_summed_up?(column)
 
     # This is a workaround to be able to sum up currency with the redmine_costs plugin
-    values = collection.map { |issue| column.respond_to?(:real_value) ? colum.real_value(issue) : column.value(issue) }.select do |value|
+    values = collection.map { |issue| column.respond_to?(:real_value) ? column.real_value(issue) : column.value(issue) }.select do |value|
       begin
         next if value.respond_to? :today? or value.is_a? String
         true if Float(value)

--- a/app/helpers/issue_list_sums_helper.rb
+++ b/app/helpers/issue_list_sums_helper.rb
@@ -80,10 +80,14 @@ module IssueListSumsHelper
   end
 
   def display_sums?
-    @query.display_sums?
+    @query.display_sums? && any_summable_columns?
   end
 
   def should_be_summed_up?(column)
     Setting.issue_list_summable_columns.include?(column.name.to_s)
+  end
+
+  def any_summable_columns?
+    Setting.issue_list_summable_columns.any?
   end
 end

--- a/app/helpers/issue_list_sums_helper.rb
+++ b/app/helpers/issue_list_sums_helper.rb
@@ -34,11 +34,13 @@ module IssueListSumsHelper
   end
 
   def sum_of(column, collection)
+    return unless should_be_summed_up?(column)
+
     # This is a workaround to be able to sum up currency with the redmine_costs plugin
-    values = collection.collect { |is| column.respond_to?(:real_value) ? column.real_value(is) : column.value(is) }.select do |val|
+    values = collection.map { |issue| column.respond_to?(:real_value) ? colum.real_value(issue) : column.value(issue) }.select do |value|
       begin
-        next if (val.respond_to? :today? or val.is_a? String)
-        true if Float(val)
+        next if value.respond_to? :today? or value.is_a? String
+        true if Float(value)
       rescue ArgumentError, TypeError
         false
       end
@@ -79,5 +81,9 @@ module IssueListSumsHelper
 
   def display_sums?
     @query.display_sums?
+  end
+
+  def should_be_summed_up?(column)
+    Setting.issue_list_summable_columns.include?(column.name.to_s)
   end
 end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -65,7 +65,7 @@ module SettingsHelper
           '<tr>' +
             '<td>' + h(text) + '</td>' +
             settings.collect do |setting|
-              '<td align="center">' + check_box_tag("settings[#{setting}][]", value, Setting.send(setting).include?(value)) + '</td>'
+              '<td align="center">' + check_box_tag("settings[#{setting}][]", value, Setting.send(setting).include?(value), :id => "#{setting}_#{value}" ) + '</td>'
             end.join +
           '</tr>'
         end.join +

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -49,6 +49,30 @@ module SettingsHelper
       end.join
   end
 
+  def settings_multiselect(settings, choices, options={})
+    '<table>' +
+      '<thead>' +
+        '<tr>' +
+          '<th>' + l(options[:label_choices] || :label_choices) + '</th>' +
+          settings.collect do |setting|
+            '<th>' + hidden_field_tag("settings[#{setting}][]", '') + l('setting_' + setting.to_s) + '</th>'
+          end.join +
+        '</tr>' +
+      '</thead>' +
+      '<tbody>' +
+        choices.collect do |choice|
+          text, value = (choice.is_a?(Array)) ? choice : [choice, choice]
+          '<tr>' +
+            '<td>' + h(text) + '</td>' +
+            settings.collect do |setting|
+              '<td align="center">' + check_box_tag("settings[#{setting}][]", value, Setting.send(setting).include?(value)) + '</td>'
+            end.join +
+          '</tr>'
+        end.join +
+      '</tbody>' +
+    '</table>'
+  end
+
   def setting_text_field(setting, options={})
     setting_label(setting, options) +
       text_field_tag("settings[#{setting}]", Setting.send(setting), options)

--- a/app/views/issues/index.rhtml
+++ b/app/views/issues/index.rhtml
@@ -33,10 +33,12 @@
 						<td><label for='group_by'><%= l(:field_group_by) %></label></td>
 						<td><%= select_tag('group_by', options_for_select([[]] + @query.groupable_columns.collect {|c| [c.caption, c.name.to_s]}, @query.group_by)) %></td>
 					</tr>
+					<% if any_summable_columns? %>
 					<tr>
 						<td><%= label_tag :display_sums, l(:label_display_sums) %></td>
 						<td><%= check_box_tag :display_sums, 1, @query.display_sums? %></td>
 					</tr>
+					<% end %>
 				</table>
       <%= call_hook(:view_issue_query_form_options_bottom, :query => @query) %>
 			</div>

--- a/app/views/queries/_form.rhtml
+++ b/app/views/queries/_form.rhtml
@@ -7,10 +7,12 @@
   <%= label_tag :query_name, l(:field_name) %>
   <%= text_field 'query', 'name', :size => 80 %>
 </p>
+<% if any_summable_columns? %>
 <p>
   <%= label_tag :display_sums, l(:label_display_sums) %>
   <%= check_box 'query', 'display_sums' %>
 </p>
+<% end %>
 
 <%= call_hook(:view_query_form_top, :query => query) %>
 

--- a/app/views/settings/_issues.rhtml
+++ b/app/views/settings/_issues.rhtml
@@ -14,9 +14,9 @@
 <p><%= setting_text_field :gantt_items_limit, :size => 6 %></p>
 </div>
 
-<fieldset class="box settings"><legend><%= l(:setting_issue_list_default_columns) %></legend>
-<%= setting_multiselect(:issue_list_default_columns,
-        Query.new.available_columns.collect {|c| [c.caption, c.name.to_s]}, :label => false) %>
+<fieldset class="box settings"><legend><%= l(:setting_column_options) %></legend>
+<%= settings_multiselect([:issue_list_default_columns, :issue_list_summable_columns],
+  Query.new.available_columns.collect {|c| [c.caption, c.name.to_s]}, :label_choices => :label_columns) %>
 </fieldset>
 
 <%= submit_tag l(:button_save) %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -350,7 +350,9 @@ de:
   setting_date_format: Datumsformat
   setting_time_format: Zeitformat
   setting_cross_project_issue_relations: Ticket-Beziehungen zwischen Projekten erlauben
-  setting_issue_list_default_columns: Default-Spalten in der Ticket-Auflistung
+  setting_column_options: Anpassen der Darstellung der Ticketlisten
+  setting_issue_list_default_columns: Standardmäßig anzeigen
+  setting_issue_list_summable_columns: Summierbar
   setting_repositories_encodings: Kodierungen der Projektarchive
   setting_commit_logs_encoding: Kodierung der Commit-Log-Meldungen
   setting_emails_footer: E-Mail-Fußzeile

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -342,7 +342,9 @@ en:
   setting_date_format: Date format
   setting_time_format: Time format
   setting_cross_project_issue_relations: Allow cross-project issue relations
-  setting_issue_list_default_columns: Default columns displayed on the issue list
+  setting_column_options: Customize the appearance of the issue lists
+  setting_issue_list_default_columns: Display by default
+  setting_issue_list_summable_columns: Summable
   setting_repositories_encodings: Repositories encodings
   setting_commit_logs_encoding: Commit messages encoding
   setting_emails_header: Emails header

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -127,6 +127,10 @@ issue_list_default_columns:
   - subject
   - assigned_to
   - updated_on
+issue_list_summable_columns:
+  serialized: true
+  default:
+  - estimated_hours
 display_subprojects_issues:
   default: 1
 issue_done_ratio:


### PR DESCRIPTION
this pull request allows to globally define which columns can be summed up

caveat:

it's still possible in the admin interface to mark columns that cannot or shouldn't be summed up (like string columns or foreign keys)

in the end, only the columns that are marked and can be summed up will be summed up..
