### PR TITLE
added support for video/* MIME types to Redmine::MimeType

### DIFF
--- a/lib/redmine/mime_type.rb
+++ b/lib/redmine/mime_type.rb
@@ -58,6 +58,11 @@ module Redmine
       'application/x-tar' => 'tar',
       'application/zip' => 'zip',
       'application/x-gzip' => 'gz',
+      'video/x-flv' => 'flv,f4v',
+      'video/mpeg' => 'mpeg,mpg,mpe',
+      'video/quicktime' => 'qt,mov',
+      'video/vnd.vivo' => 'viv,vivo',
+      'video/x-msvideo' => 'avi',
     }.freeze
 
     EXTENSIONS = MIME_TYPES.inject({}) do |map, (type, exts)|


### PR DESCRIPTION
So far redmine's MIME type detection does not account for videos. This will be required for the video_upload plugin however, so I added this into the core instead of somehow patching Redmine::MimeType from the plugin.
