### PR TITLE
use non-deprecated way of asking if there is a content_for block in wiki...

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -95,10 +95,10 @@
       <%= render_flash_messages %>
 
       <!-- Action menu -->
-      <% if @content_for_action_menu_main %>
+      <% if content_for?(:action_menu_main) %>
         <ul class="action_menu_main">
           <%= yield :action_menu_main %>
-          <% if @content_for_action_menu_more %>
+          <% if content_for?(:action_menu_more) %>
             <li class="drop-down">
               <a href="javascript:" class="icon icon-more"><%= l(:more_actions) %></a>
               <ul class="action_menu_more" style="display:none;">


### PR DESCRIPTION
...-show view

replace occurences of

```
@content_for_<symbol>
```

with

```
content_for?(:<symbol>)
```

> The deprecated way of accessing a content_for block is to use an instance variable named @content_for_#{name_of_the_content_block}. The preferred usage is now <%= yield :footer %>.

source: http://apidock.com/rails/v2.3.8/ActionView/Helpers/CaptureHelper/content_for
