### PR TITLE
Fix/improved navigation toggler

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -722,13 +722,32 @@ $(window).bind('resizeEnd', function() {
           });
         });
 
-        jQuery('#toggle-project-menu .navigation-toggler').click(function(){
+        // users of some old IEs are out of luck ATM. An userData
+        // implementation could be provided though, that would be great!
+        var remember_menu_state = function(match) {
+          if (typeof window.sessionStorage != 'undefined') {
+            if (typeof match == 'undefined') {
+              return sessionStorage.getItem('navigation-toggle');
+            } else {
+              return sessionStorage.setItem('navigation-toggle', match.length > 0 ? 'collapsed' : 'expanded')
+            }
+          }
+          return false;
+        };
+
+        var toggle_navigation = function() {
           var height = $(document).height() - $('#main-menu').offset().top - 32;
           $('#main-menu, #menu-sidebar').toggleClass('hidden');
           $('#content').toggleClass('hidden-navigation');
           $('#toggle-project-menu').removeAttr("style").toggleClass('show');
-          $('#toggle-project-menu.show').css({height:height});
-        });
+          remember_menu_state($('#toggle-project-menu.show').css({height:height}));
+        };
+
+        // register toggler, and toggle for the first time if remembered to be closed.
+        jQuery('#toggle-project-menu .navigation-toggler').click(toggle_navigation);
+        if ($('#main-menu').length > 0 && remember_menu_state() === "collapsed") {
+          toggle_navigation();
+        }
 });
 
 var Administration = (function ($) {

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -722,24 +722,12 @@ $(window).bind('resizeEnd', function() {
           });
         });
 
-        jQuery('#main-menu #toggle-project-menu a.navigation-toggler').click(function(){
-          if ($('#main-menu #toggle-project-menu').hasClass('show')) {
-            // Show project navigation
-            $('#main-menu').removeClass('hidden')
-            $('#menu-sidebar').removeClass('hidden');
-            $('#main-menu #toggle-project-menu').removeClass('show');
-            $('#main-menu #toggle-project-menu').removeAttr("style");
-            $('#content').removeClass('hidden-navigation');
-          }
-          else {
-            // Hide project navigation
-            var height = $(document).height();
-            $('#main-menu').addClass('hidden');
-            $('#menu-sidebar').addClass('hidden');
-            $('#main-menu #toggle-project-menu').addClass('show');
-            $('#main-menu #toggle-project-menu.show').css({height:height});
-            $('#content').addClass('hidden-navigation');
-          };
+        jQuery('#toggle-project-menu .navigation-toggler').click(function(){
+          var height = $(document).height();
+          $('#main-menu, #menu-sidebar').toggleClass('hidden');
+          $('#content').toggleClass('hidden-navigation');
+          $('#toggle-project-menu').removeAttr("style").toggleClass('show');
+          $('#toggle-project-menu.show').css({height:height});
         });
 });
 

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -723,7 +723,7 @@ $(window).bind('resizeEnd', function() {
         });
 
         jQuery('#toggle-project-menu .navigation-toggler').click(function(){
-          var height = $(document).height();
+          var height = $(document).height() - $('#main-menu').offset().top - 32;
           $('#main-menu, #menu-sidebar').toggleClass('hidden');
           $('#content').toggleClass('hidden-navigation');
           $('#toggle-project-menu').removeAttr("style").toggleClass('show');


### PR DESCRIPTION
On small screens, users tend to actually collapse the navigation tree. Annoyingly, a collapsed menu is open again when navigating to another page. This pull request refactors the bloated toggler and adds sessionStorage to store expansion state. Tested in current Chrome, a rather current Firefox (~13) and IE8.
