### PR TITLE
extracted base.rhtml footer into ApplicationHelper method call

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1128,6 +1128,15 @@ module ApplicationHelper
   def accessibility_js_enabled?
     !@accessibility_js_disabled
   end
+  
+  #
+  # Returns the footer text displayed in the layout file.
+  #
+  def layout_footer_text
+    %Q{<div class="bgl"><div class="bgr">} +
+      l(:text_powered_by, :link => link_to(Redmine::Info.app_name, Redmine::Info.url)) +
+    %Q{</div></div>}
+  end
 
   private
 

--- a/app/views/layouts/base.rhtml
+++ b/app/views/layouts/base.rhtml
@@ -118,9 +118,7 @@
   </div>
 
   <div id="footer">
-    <div class="bgl"><div class="bgr">
-        <%= l(:text_powered_by, :link => link_to(Redmine::Info.app_name, Redmine::Info.url)) %>
-      </div></div>
+    <%= layout_footer_text %>
   </div>
 
   <div id="ajax-indicator" style="display:none;"><span><%= l(:label_loading) %></span></div>


### PR DESCRIPTION
The content of the footer div in base.rhtml has been extracted to an ApplicationHelper method, so it can be better customized / overwritten by plugins, e.g. using alias_method_chain.
