### PR TITLE
considerates renamed wiki start pages on migrating to wiki_menu_items

### DIFF
--- a/db/migrate/20120809131659_create_wiki_menu_item_for_existing_wikis.rb
+++ b/db/migrate/20120809131659_create_wiki_menu_item_for_existing_wikis.rb
@@ -1,9 +1,16 @@
 class CreateWikiMenuItemForExistingWikis < ActiveRecord::Migration
   def self.up
     Wiki.all.each do |wiki|
+
+      page = wiki.find_page(wiki.start_page, :with_redirects => true)
+
+      current_title = page.present? ?
+                        page.title :
+                        wiki.start_page
+
       menu_item = WikiMenuItem.new
       menu_item.name = wiki.start_page
-      menu_item.title = wiki.start_page
+      menu_item.title = current_title
       menu_item.wiki_id = wiki.id
       menu_item.index_page = true
       menu_item.new_wiki_page = true


### PR DESCRIPTION
- as the implementation of wiki_menu_items requires the title noted in the menu_item to match the current title of the wiki_page we retrieve the current title on migration rather than just taking the title noted as start_page attribute of the wiki

If possible, please check whether the start_page attribute can be removed.
