### PR TITLE
Being more defensive when trying to delete membership after last role was removed

### DIFF
--- a/app/models/member_role.rb
+++ b/app/models/member_role.rb
@@ -35,7 +35,7 @@ class MemberRole < ActiveRecord::Base
   private
 
   def remove_member_if_empty
-    if member.roles.empty?
+    if member and member.roles.empty?
       member.destroy
     end
   end

--- a/app/views/reports/issue_report.rhtml
+++ b/app/views/reports/issue_report.rhtml
@@ -46,7 +46,7 @@
 <%= render :partial => 'simple', :locals => { :data => @issues_by_version, :field_name => "fixed_version_id", :rows => @versions } %>
 <br />
 <% if @project.children.any? %>
-<h3><%=l(:label_suproject_plural)%>&nbsp;&nbsp;
+<h3><%=l(:label_subproject_plural)%>&nbsp;&nbsp;
   <%= link_to image_tag('zoom_in.png',
                         :alt    => l(:text_analyze, :subject => l(:field_subproject)),
                         :title  => l(:text_analyze, :subject => l(:field_subproject))),

--- a/db/migrate/20120809131659_create_wiki_menu_item_for_existing_wikis.rb
+++ b/db/migrate/20120809131659_create_wiki_menu_item_for_existing_wikis.rb
@@ -1,9 +1,16 @@
 class CreateWikiMenuItemForExistingWikis < ActiveRecord::Migration
   def self.up
     Wiki.all.each do |wiki|
+
+      page = wiki.find_page(wiki.start_page, :with_redirects => true)
+
+      current_title = page.present? ?
+                        page.title :
+                        wiki.start_page
+
       menu_item = WikiMenuItem.new
       menu_item.name = wiki.start_page
-      menu_item.title = wiki.start_page
+      menu_item.title = current_title
       menu_item.wiki_id = wiki.id
       menu_item.index_page = true
       menu_item.new_wiki_page = true


### PR DESCRIPTION
In certain scenarios - when programmatically interacting with roles and memberships - it is possible, that the member was already deleted. In this case, the code raised a NullPointerException. The proposed fix is more defensive when trying to delete the member. There is no reason to 'freak out' when there is no member present.

Thanks for taking a look.

Gregor
